### PR TITLE
fix icon embed when app is installed

### DIFF
--- a/src/config_h.rs.in
+++ b/src/config_h.rs.in
@@ -1,26 +1,25 @@
-pub mod global {
 
-  use std::path::Path;
 
-  fn get_datadir() -> &'static str {
-    "@prefix@/share/"
+use std::path::Path;
+
+fn get_datadir() -> &'static str {
+  "@prefix@/share/"
+}
+
+pub fn get_assetsdir() -> String {
+  if Path::new("./assets/cards").exists() {
+    return ".".to_owned();
   }
+  format!("{}/{}", get_datadir(), "@PACKAGE_TARNAME@")
+}
 
-  pub fn get_assetsdir() -> String {
-    if Path::new("./assets/cards").exists() {
-      return ".".to_owned();
-    }
-    format!("{}/{}", get_datadir(), "@PACKAGE_TARNAME@")
-  }
+pub fn get_localedir() -> String {
+  format!("{}/{}", get_datadir(), "locale")
+}
 
-  pub fn get_localedir() -> String {
-    format!("{}/{}", get_datadir(), "locale")
+pub fn get_pixmapsdir() -> String {
+  if Path::new("./assets").exists() {
+    return "./assets".to_owned();
   }
-
-  pub fn get_pixmapsdir() -> String {
-    if Path::new("./assets").exists() {
-      return "./assets".to_owned();
-    }
-    format!("{}/{}", get_datadir(), "pixmaps")
-  }
+  format!("{}/{}", get_datadir(), "pixmaps")
 }

--- a/src/config_h.rs.in
+++ b/src/config_h.rs.in
@@ -1,12 +1,26 @@
-use std::path::Path;
+pub mod global {
 
-pub fn get_assetsdir() -> &'static str {
-  if Path::new("./assets/cards").exists() {
-    return ".";
+  use std::path::Path;
+
+  fn get_datadir() -> &'static str {
+    "@prefix@/share/"
   }
-  "@prefix@/share/@PACKAGE_TARNAME@"
-}
 
-pub fn get_localedir() -> &'static str {
-  "@prefix@/share/locale"
+  pub fn get_assetsdir() -> String {
+    if Path::new("./assets/cards").exists() {
+      return ".".to_owned();
+    }
+    format!("{}/{}", get_datadir(), "@PACKAGE_TARNAME@")
+  }
+
+  pub fn get_localedir() -> String {
+    format!("{}/{}", get_datadir(), "locale")
+  }
+
+  pub fn get_pixmapsdir() -> String {
+    if Path::new("./assets").exists() {
+      return "./assets".to_owned();
+    }
+    format!("{}/{}", get_datadir(), "pixmaps")
+  }
 }

--- a/src/gui/asset_manager.rs
+++ b/src/gui/asset_manager.rs
@@ -1,3 +1,4 @@
+use crate::config_h::global;
 use iced::{window::Icon, Length, Svg};
 use image::{io::Reader as ImageReader, ImageResult, RgbaImage};
 use ionic_deckhandler::{Card, Rank, Suit};
@@ -5,13 +6,9 @@ use ionic_deckhandler::{Card, Rank, Suit};
 // TODO: these assets can take time to load. Perhaps look at way to cache them.
 // Card display.
 fn card_img(card_name: &str) -> Svg {
-    Svg::from_path(format!(
-        "{}/assets/cards/{}",
-        telluricdeckay::config_h::get_assetsdir(),
-        card_name
-    ))
-    .width(Length::Units(50))
-    .height(Length::Units(50))
+    Svg::from_path(format!("{}/assets/cards/{}", global::get_assetsdir(), card_name))
+        .width(Length::Units(50))
+        .height(Length::Units(50))
 }
 
 trait CardToImg {
@@ -248,11 +245,7 @@ fn get_rgba8img(filename: &str) -> ImageResult<RgbaImage> {
 }
 
 pub fn get_icon() -> Option<Icon> {
-    get_rgba8img(&format!(
-        "{}/assets/telluricdeckay.png",
-        telluricdeckay::config_h::get_assetsdir()
-    ))
-    .map_or_else(
+    get_rgba8img(&format!("{}/telluricdeckay.png", global::get_pixmapsdir())).map_or_else(
         |e| {
             eprintln!("Could not load image: {:?}", e);
             None

--- a/src/gui/asset_manager.rs
+++ b/src/gui/asset_manager.rs
@@ -1,4 +1,4 @@
-use crate::config_h::global;
+use crate::config_h;
 use iced::{window::Icon, Length, Svg};
 use image::{io::Reader as ImageReader, ImageResult, RgbaImage};
 use ionic_deckhandler::{Card, Rank, Suit};
@@ -6,7 +6,7 @@ use ionic_deckhandler::{Card, Rank, Suit};
 // TODO: these assets can take time to load. Perhaps look at way to cache them.
 // Card display.
 fn card_img(card_name: &str) -> Svg {
-    Svg::from_path(format!("{}/assets/cards/{}", global::get_assetsdir(), card_name))
+    Svg::from_path(format!("{}/assets/cards/{}", config_h::get_assetsdir(), card_name))
         .width(Length::Units(50))
         .height(Length::Units(50))
 }
@@ -245,7 +245,7 @@ fn get_rgba8img(filename: &str) -> ImageResult<RgbaImage> {
 }
 
 pub fn get_icon() -> Option<Icon> {
-    get_rgba8img(&format!("{}/telluricdeckay.png", global::get_pixmapsdir())).map_or_else(
+    get_rgba8img(&format!("{}/telluricdeckay.png", config_h::get_pixmapsdir())).map_or_else(
         |e| {
             eprintln!("Could not load image: {:?}", e);
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod config_h;
+use config_h::global;
 mod game;
 mod gui;
 mod player;
@@ -16,7 +17,7 @@ use tr::tr_init;
 struct Translations;
 
 fn main() -> Result<(), Error> {
-    tr_init!(crate::config_h::get_localedir());
+    tr_init!(global::get_localedir());
     let translations = Translations {};
     let language_loader = gettext_language_loader!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 mod config;
 mod config_h;
-use config_h::global;
 mod game;
 mod gui;
 mod player;
@@ -17,7 +16,7 @@ use tr::tr_init;
 struct Translations;
 
 fn main() -> Result<(), Error> {
-    tr_init!(global::get_localedir());
+    tr_init!(config_h::get_localedir());
     let translations = Translations {};
     let language_loader = gettext_language_loader!();
 


### PR DESCRIPTION
Related to https://github.com/TelluricDeckay/telluricdeckay/commit/fdd44528e01da66163fa2ed790dc819775c31abb

Testing installation, I found the icon in the upper-left corner missing, and got this message when running the app:

```
Could not load image: IoError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

This patch fixes it.

Even after this patch was working, I got warnings like "function get_assetsdir is never used". Even though it was being used.

Seemed the only way to get rid of those warnings was to add this to the top of asset_manager.rs

`use crate::config_h;`

