### PR TITLE
rust.yml:specify the trunk branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,9 +3,11 @@ name: Rust
 # Triggers the workflow on push or pull request events
 on:
   push:
+    branches: trunk
     paths-ignore:
     - '**.md'
   pull_request:
+    branches: trunk
     paths-ignore:
     - '**.md'
 


### PR DESCRIPTION
The reason I'm specifying the branch is because when a branch is pushed and then a PR is opened, it does the test on both. Then if the branch changes (thereby updating the PR), it will test the branch again, and also the PR.